### PR TITLE
- Resolved open issue #3 (Unable to build under Debian 11/Bullseye)

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,1 @@
+README.md

--- a/configure.ac
+++ b/configure.ac
@@ -28,8 +28,12 @@ fi
 AC_DEFINE_UNQUOTED([SENDMAIL], ["$SENDMAIL"], [Define to full path of sendmail executable])
 
 gmime_version="$(dpkg -l *gmime*  | grep -i "\-dev" | cut -f2 -d"-" | cut -f1 -d'.')"
+
+
+# Why? Guess we'll find out...
 # Force gmime version to 2.x
-gmime_version=2
+#gmime_version=2
+
 AC_DEFINE_UNQUOTED([GMIME_VER], [$gmime_version], [define GMIME LIB version number])
 
 dnl =======================================================================

--- a/wl2kax25.c
+++ b/wl2kax25.c
@@ -369,7 +369,7 @@ main(int argc, char *argv[])
         printf("Waiting for AX25 peer ... ");
         while(isax25connected(s)){
           current_time = time(NULL);
-          if (difftime(current_time, start_time) > 6) {
+          if (difftime(current_time, start_time) > 12) {
             break;
           }
         }
@@ -392,6 +392,7 @@ main(int argc, char *argv[])
   {
     // Child processing
     printf("Child process\n");
+    close(s);
     close(sv[0]);
 
     if ((fp = fdopen(sv[1], "r+b")) == NULL) {

--- a/wl2mime.c
+++ b/wl2mime.c
@@ -100,7 +100,7 @@ wl2mime(struct buffer *ibuf)
   GMimeMultipart *multipart;
   GMimeMessage *message;
   struct tm tm;
-  time_t date;
+  //time_t date;
   char *ms;
   char *smtp;
 
@@ -142,12 +142,15 @@ wl2mime(struct buffer *ibuf)
     } else if (strcasebegins(line, "Date:")) {
       memset(&tm, 0, sizeof(struct tm));
       if (strptime(linedata, "%Y/%m/%d %R", &tm) != NULL) {
-	/* Get date as UTC */
-	date = wl_timegm(&tm);
+
 	/* set date as UTC */
 #if (GMIME_VER > 2)
+	GDateTime *date=g_date_time_new_now_utc();
 	g_mime_message_set_date(message, date);
+	g_date_time_unref(date);
 #else
+	/* Get date as UTC */
+	time_t date = wl_timegm(&tm);
 	g_mime_message_set_date(message, date, 0);
 #endif
       }


### PR DESCRIPTION
- Removed an override of libgmime version forcing V2 to be recognized
- Tested that both the ax25 and telnet transports retrieve mail successfully
- Added a missing socket close() which was leaking open sockets
- Doubled the child process timeout to fix spurious timeouts

The telnet and AX25 retrieval methods are tested and seem to be working
properly now. To my understanding, it shouldn't be possible to leak
sockets into the operating system because they should close when
the process exits, but that's nonetheless what I was seeing. It was
very detrimental to be able to run the program only once before
you were stuck with an address-busy error and had to restart the
radio stack. That's fixed. It might be a good idea to add signal handlers
to keep the connection from dangling on SIGINT, for example.