### PR TITLE
Resolved Issue #3 (Cannot build with libgmime 3 or Debian 11/Bullseye)

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,1 @@
+README.md

--- a/configure.ac
+++ b/configure.ac
@@ -28,8 +28,12 @@ fi
 AC_DEFINE_UNQUOTED([SENDMAIL], ["$SENDMAIL"], [Define to full path of sendmail executable])
 
 gmime_version="$(dpkg -l *gmime*  | grep -i "\-dev" | cut -f2 -d"-" | cut -f1 -d'.')"
+
+
+# Why? Guess we'll find out...
 # Force gmime version to 2.x
-gmime_version=2
+#gmime_version=2
+
 AC_DEFINE_UNQUOTED([GMIME_VER], [$gmime_version], [define GMIME LIB version number])
 
 dnl =======================================================================

--- a/wl2kax25.c
+++ b/wl2kax25.c
@@ -369,7 +369,7 @@ main(int argc, char *argv[])
         printf("Waiting for AX25 peer ... ");
         while(isax25connected(s)){
           current_time = time(NULL);
-          if (difftime(current_time, start_time) > 6) {
+          if (difftime(current_time, start_time) > 12) {
             break;
           }
         }
@@ -392,6 +392,7 @@ main(int argc, char *argv[])
   {
     // Child processing
     printf("Child process\n");
+    close(s);
     close(sv[0]);
 
     if ((fp = fdopen(sv[1], "r+b")) == NULL) {

--- a/wl2mime.c
+++ b/wl2mime.c
@@ -142,11 +142,15 @@ wl2mime(struct buffer *ibuf)
     } else if (strcasebegins(line, "Date:")) {
       memset(&tm, 0, sizeof(struct tm));
       if (strptime(linedata, "%Y/%m/%d %R", &tm) != NULL) {
-	/* Get date as UTC */
-	date = wl_timegm(&tm);
+
 	/* set date as UTC */
+	
+	/* Get date as UTC */
+	time_t date = wl_timegm(&tm);
 #if (GMIME_VER > 2)
-	g_mime_message_set_date(message, date);
+	GDateTime *gdate=g_date_time_new_from_unix_utc(date);
+	g_mime_message_set_date(message, gdate);
+	g_date_time_unref(gdate);
 #else
 	g_mime_message_set_date(message, date, 0);
 #endif


### PR DESCRIPTION
Technically, at the previous commit, you could build it, but it would segfault due to a type safety failure
and incompatibility.

- Removed the override which forces gmime version detection to v2
- Fixed the transfer of the message date between Winlink and MIME header for gmime 3
- That seemed to be the last thing missing for gmime 3 to work, but I have not tested the serial transport
- Doubled the fork process timeout to avoid spurious timeouts
- Added a missing close() call in the forked process which appeared to be leaking sockets into the operating system

The last item is especially weird, since I don't think it's supposed to be possible; the OS is supposed to close
all file handles (including sockets) upon process exit, so maybe it represents a kernel or driver bug. Anyway, I
find it a valuable workaround, as I would otherwise have to restart the radio stack after every run.
This leak may happen anyway if the program closes abnormally, but at least it's fixed for the more common cases.
If it persists, we might want to put the socket close in a signal or termination handler.